### PR TITLE
Improve ports handling

### DIFF
--- a/unmessage/cli.py
+++ b/unmessage/cli.py
@@ -873,7 +873,7 @@ def main(name=None):
     parser.add_argument('-n', '--name',
                         default=name)
     parser.add_argument('-l', '--local-server-port',
-                        default=peer.PORT,
+                        default=None,
                         type=int)
     parser.add_argument('--no-tor-process',
                         action='store_false')

--- a/unmessage/cli.py
+++ b/unmessage/cli.py
@@ -193,7 +193,7 @@ class Cli(PeerUi):
 
     def start(self, name,
               local_server_port=None,
-              start_tor_process=True,
+              start_tor_socks=True,
               use_tor_proxy=True,
               tor_port=None,
               start_onion_server=True,
@@ -210,7 +210,7 @@ class Cli(PeerUi):
             curses.wrapper(self.start_main,
                            name,
                            local_server_port,
-                           start_tor_process,
+                           start_tor_socks,
                            use_tor_proxy,
                            tor_port,
                            start_onion_server,
@@ -227,7 +227,7 @@ class Cli(PeerUi):
 
     def init_peer(self, name,
                   local_server_port,
-                  start_tor_process,
+                  start_tor_socks,
                   use_tor_proxy,
                   tor_port,
                   start_onion_server,
@@ -235,7 +235,7 @@ class Cli(PeerUi):
                   local_mode):
         self.peer = Peer(name, self)
         self.peer.start(local_server_port,
-                        start_tor_process,
+                        start_tor_socks,
                         use_tor_proxy,
                         tor_port,
                         start_onion_server,
@@ -382,7 +382,7 @@ class Cli(PeerUi):
     def start_main(self, stdscr,
                    name,
                    local_server_port,
-                   start_tor_process,
+                   start_tor_socks,
                    use_tor_proxy,
                    tor_port,
                    start_onion_server,
@@ -396,7 +396,7 @@ class Cli(PeerUi):
         try:
             self.init_peer(name,
                            local_server_port,
-                           start_tor_process,
+                           start_tor_socks,
                            use_tor_proxy,
                            tor_port,
                            start_onion_server,
@@ -875,7 +875,7 @@ def main(name=None):
     parser.add_argument('-l', '--local-server-port',
                         default=None,
                         type=int)
-    parser.add_argument('--no-tor-process',
+    parser.add_argument('--no-tor-socks',
                         action='store_false')
     parser.add_argument('--no-tor-proxy',
                         action='store_false')
@@ -897,7 +897,7 @@ def main(name=None):
     cli = Cli()
     cli.start(args.name,
               args.local_server_port,
-              args.no_tor_process,
+              args.no_tor_socks,
               args.no_tor_proxy,
               args.tor_port,
               args.no_onion_service,

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -570,7 +570,7 @@ class Peer(object):
         else:
             raise errors.CorruptedPacketError()
 
-    def _start_server(self, start_tor_process, start_onion_server):
+    def _start_server(self, start_tor_socks, start_onion_server):
         self._ui.notify_bootstrap(
             notifications.UnmessageNotification('Configuring local server'))
 
@@ -585,7 +585,7 @@ class Peer(object):
             self._ui.notify_bootstrap(
                 notifications.UnmessageNotification('Running local server'))
 
-            d_tor = self._config_tor(start_tor_process, start_onion_server)
+            d_tor = self._config_tor(start_tor_socks, start_onion_server)
             if d_tor:
                 d_tor.addCallbacks(d.callback, d.errback)
             else:
@@ -608,8 +608,8 @@ class Peer(object):
 
         return d
 
-    def _config_tor(self, start_tor_process, start_onion_server):
-        if start_tor_process or start_onion_server:
+    def _config_tor(self, start_tor_socks, start_onion_server):
+        if start_tor_socks or start_onion_server:
             self._ui.notify_bootstrap(
                 notifications.UnmessageNotification('Configuring Tor'))
 
@@ -617,16 +617,16 @@ class Peer(object):
             config.DataDirectory = self._path_tor_data_dir
             config.ControlPort = self._port_tor_control
 
-            if start_tor_process:
+            if start_tor_socks:
                 self._ui.notify_bootstrap(
                     notifications.UnmessageNotification(
-                        'Configuring Tor process'))
+                        'Configuring Tor SOCKS port'))
 
                 config.SocksPort = self._port_tor
             else:
                 self._ui.notify_bootstrap(
                     notifications.UnmessageNotification(
-                        "Using the system's Tor process"))
+                        "Using the system's Tor SOCKS port"))
 
             if start_onion_server:
                 self._ui.notify_bootstrap(
@@ -662,7 +662,7 @@ class Peer(object):
         else:
             self._ui.notify_bootstrap(
                 notifications.UnmessageNotification(
-                    "Using the system's Tor process and Onion Service"))
+                    "Using the system's Tor SOCKS port and Onion Service"))
             return None
 
     def _send_request(self, identity, key):
@@ -784,14 +784,14 @@ class Peer(object):
                         'found'))
 
     def start(self, local_server_port=None,
-              start_tor_process=True,
+              start_tor_socks=True,
               use_tor_proxy=True,
               tor_port=None,
               start_onion_server=True,
               tor_control_port=None,
               local_mode=False):
         if local_mode:
-            start_tor_process = False
+            start_tor_socks = False
             use_tor_proxy = False
             start_onion_server = False
             self._local_mode = local_mode
@@ -843,7 +843,7 @@ class Peer(object):
         def errback(reason):
             self._ui.notify_error(errors.UnmessageError(str(reason)))
 
-        d = self._start_server(start_tor_process, start_onion_server)
+        d = self._start_server(start_tor_socks, start_onion_server)
         d.addCallbacks(peer_started, peer_failed)
         d.addErrback(errback)
 

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -788,6 +788,13 @@ class Peer(object):
             use_tor_proxy = False
             start_onion_server = False
             self._local_mode = local_mode
+        self._ui.notify_bootstrap(
+            notifications.UnmessageNotification('Starting peer'))
+
+        self._create_peer_dir()
+        self._load_peer_info()
+        self._update_config()
+
         if local_server_port:
             self._port_local_server = int(local_server_port)
         self._use_tor_proxy = use_tor_proxy
@@ -795,13 +802,6 @@ class Peer(object):
             self._port_tor = int(tor_port)
         if tor_control_port:
             self._port_tor_control = int(tor_control_port)
-
-        self._ui.notify_bootstrap(
-            notifications.UnmessageNotification('Starting peer'))
-
-        self._create_peer_dir()
-        self._load_peer_info()
-        self._update_config()
 
         def peer_started(result):
             self._ui.notify_bootstrap(

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -294,7 +294,7 @@ class Peer(object):
         if self._use_tor_proxy:
             point = TorClientEndpoint(address.host, address.port,
                                       socks_hostname=HOST,
-                                      socks_port=self._tor_config.SocksPort)
+                                      socks_port=self._port_tor)
         else:
             if self._local_mode:
                 host = HOST


### PR DESCRIPTION
The biggest change is the persistence of the server port used by the
peer and requires some changes to `peer.db`
(see 877aef1fd2c0abbfa8f7773b19950dee3106414a).

It also allows the use of the system's Tor SOCKS port and changes the
name of the flag which starts unMessage's own Tor process' SOCKS port.