### PR TITLE
Improve handling of unusual packets

### DIFF
--- a/unmessage/packets.py
+++ b/unmessage/packets.py
@@ -16,12 +16,16 @@ LINESEP = '\n'
 
 def raise_malformed(f):
     @wraps(f)
-    def try_building(*args, **kwargs):
+    def try_building(data):
         try:
-            return f(*args, **kwargs)
+            return f(data)
         except (AssertionError, IndexError, TypeError):
             packet_type = f.func_name.split('_')[1]
-            raise errors.MalformedPacketError(packet_type)
+            e = errors.MalformedPacketError(packet_type)
+            indexed_lines = ['[{}]: {}'.format(index, line)
+                             for index, line in enumerate(data.splitlines())]
+            e.message = LINESEP.join([e.message] + indexed_lines)
+            raise e
     return try_building
 
 

--- a/unmessage/packets.py
+++ b/unmessage/packets.py
@@ -20,6 +20,15 @@ def raise_malformed(f):
 
 
 @raise_malformed
+def build_intro_packet(data):
+    lines = data.splitlines()
+    packet = IntroductionPacket(iv=lines[0],
+                                iv_hash=lines[1],
+                                data=data)
+    return packet
+
+
+@raise_malformed
 def build_regular_packet(data):
     return RegularPacket(*data.splitlines())
 
@@ -42,6 +51,16 @@ def build_element_packet(data):
                          part_num=lines[2],
                          part_len=lines[3],
                          payload=lines[4])
+
+
+class IntroductionPacket:
+    def __init__(self, iv, iv_hash, data):
+        self.iv = iv
+        self.iv_hash = iv_hash
+        self.data = data
+
+    def __str__(self):
+        return self.data
 
 
 class RegularPacket:

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -909,7 +909,7 @@ class Introduction(Thread):
         self.peer = peer
         self.connection = connection
 
-        self.connection.manager = self
+        self.connection.add_manager(self)
 
     def run(self):
         data = self.queue_in_data.get()

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -1068,7 +1068,7 @@ class Conversation(object):
         self.queue_in_packets.put([packet, self])
 
     def handle_out_req_data(self, data):
-        packet = packets.build_regular_packet(data)
+        packet = packets.build_reply_packet(data)
         req = self.peer._outbound_requests[self.contact.identity]
         enc_handshake_key = a2b(packet.handshake_key)
 

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -924,7 +924,7 @@ class Introduction(Thread):
             self.peer._ui.notify_error(e)
 
     def handle_introduction_data(self, data):
-        packet = packets.build_regular_packet(data)
+        packet = packets.build_intro_packet(data)
 
         for conv in self.peer.conversations:
             keys = conv.keys or conv.request_keys

--- a/unmessage/peer.py
+++ b/unmessage/peer.py
@@ -916,11 +916,6 @@ class Introduction(Thread):
         try:
             self.handle_introduction_data(data)
         except errors.MalformedPacketError as e:
-            indexed_lines = [
-                '[{}]: {}'.format(index, line)
-                for index, line in enumerate(data.splitlines())]
-            e.message = '\n'.join(['{}: {}'.format(e.title, e.message)] +
-                                  indexed_lines)
             self.peer._ui.notify_error(e)
 
     def handle_introduction_data(self, data):
@@ -1032,11 +1027,6 @@ class Conversation(object):
                 # TODO maybe disconnect instead of ignoring the data
                 pass
             except errors.MalformedPacketError as e:
-                indexed_lines = [
-                    '[{}]: {}'.format(index, line)
-                    for index, line in enumerate(data.splitlines())]
-                e.message = '\n'.join(['{}: {}'.format(e.title, e.message)] +
-                                      indexed_lines)
                 self.peer._ui.notify_error(e)
 
     def check_out_data(self):


### PR DESCRIPTION
unMessage would crash when receiving packets different than what expected. These changes attempt to catch those cases and display when they occur. More work must be done once we define exactly how the packet format looks like.

There is still a need to handle the "inner" packets, the elements, which are encrypted and exchanged when conversations are already established, but first we should also define a format/protocol for those. As they are wrapped by regular packets, we should probably use something that is already available out there.

Let me know what you think!