### PR TITLE
Add hypothesis tests for the packets module

### DIFF
--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -15,6 +15,7 @@ CORRECT_LEN_KEY = random(packets.KEY_LEN)
 CORRECT_LEN_ENC_KEY = random(packets.ENC_KEY_LEN)
 CORRECT_LEN_PAYLOAD = random(1)
 CORRECT_LEN_HANDSHAKE_PACKET = random(1)
+CORRECT_LEN_IDENTITY = random(1)
 
 
 def join_encode_data(lines):
@@ -127,3 +128,34 @@ def test_build_request_packet(iv,
     else:
         with pytest.raises(errors.MalformedPacketError):
             packets.build_request_packet(data)
+
+
+@given(
+    binary(),
+    binary(),
+    binary(),
+    binary(),
+)
+@example(
+    CORRECT_LEN_IDENTITY,
+    CORRECT_LEN_KEY,
+    CORRECT_LEN_KEY,
+    CORRECT_LEN_KEY,
+)
+def test_build_handshake_packet(identity,
+                                identity_key,
+                                handshake_key,
+                                ratchet_key):
+    data = join_encode_data([identity,
+                             identity_key,
+                             handshake_key,
+                             ratchet_key])
+    if (len(identity) and
+            len(identity_key) == packets.KEY_LEN and
+            len(handshake_key) == packets.KEY_LEN and
+            len(ratchet_key) == packets.KEY_LEN):
+        assert isinstance(packets.build_handshake_packet(data),
+                          packets.HandshakePacket)
+    else:
+        with pytest.raises(errors.MalformedPacketError):
+            packets.build_handshake_packet(data)

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -11,6 +11,7 @@ from pyaxo import b2a
 
 CORRECT_LEN_IV = random(packets.IV_LEN)
 CORRECT_LEN_HASH = random(packets.HASH_LEN)
+CORRECT_LEN_ENC_KEY = random(packets.ENC_KEY_LEN)
 CORRECT_LEN_PAYLOAD = random(1)
 
 
@@ -52,3 +53,39 @@ def test_build_regular_packet(iv,
     else:
         with pytest.raises(errors.MalformedPacketError):
             packets.build_regular_packet(data)
+
+
+@given(
+    binary(),
+    binary(),
+    binary(),
+    binary(),
+    binary(),
+)
+@example(
+    CORRECT_LEN_IV,
+    CORRECT_LEN_HASH,
+    CORRECT_LEN_HASH,
+    CORRECT_LEN_ENC_KEY,
+    CORRECT_LEN_PAYLOAD,
+)
+def test_build_reply_packet(iv,
+                            iv_hash,
+                            payload_hash,
+                            handshake_key,
+                            payload):
+    data = join_encode_data([iv,
+                             iv_hash,
+                             payload_hash,
+                             handshake_key,
+                             payload])
+    if (len(iv) == packets.IV_LEN and
+            len(iv_hash) == packets.HASH_LEN and
+            len(payload_hash) == packets.HASH_LEN and
+            len(handshake_key) == packets.ENC_KEY_LEN and
+            len(payload)):
+        assert isinstance(packets.build_reply_packet(data),
+                          packets.RegularPacket)
+    else:
+        with pytest.raises(errors.MalformedPacketError):
+            packets.build_reply_packet(data)

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -11,8 +11,10 @@ from pyaxo import b2a
 
 CORRECT_LEN_IV = random(packets.IV_LEN)
 CORRECT_LEN_HASH = random(packets.HASH_LEN)
+CORRECT_LEN_KEY = random(packets.KEY_LEN)
 CORRECT_LEN_ENC_KEY = random(packets.ENC_KEY_LEN)
 CORRECT_LEN_PAYLOAD = random(1)
+CORRECT_LEN_HANDSHAKE_PACKET = random(1)
 
 
 def join_encode_data(lines):
@@ -89,3 +91,39 @@ def test_build_reply_packet(iv,
     else:
         with pytest.raises(errors.MalformedPacketError):
             packets.build_reply_packet(data)
+
+
+@given(
+    binary(),
+    binary(),
+    binary(),
+    binary(),
+    binary(),
+)
+@example(
+    CORRECT_LEN_IV,
+    CORRECT_LEN_HASH,
+    CORRECT_LEN_HASH,
+    CORRECT_LEN_KEY,
+    CORRECT_LEN_HANDSHAKE_PACKET,
+)
+def test_build_request_packet(iv,
+                              iv_hash,
+                              handshake_packet_hash,
+                              request_key,
+                              handshake_packet):
+    data = join_encode_data([iv,
+                             iv_hash,
+                             handshake_packet_hash,
+                             request_key,
+                             handshake_packet])
+    if (len(iv) == packets.IV_LEN and
+            len(iv_hash) == packets.HASH_LEN and
+            len(handshake_packet_hash) == packets.HASH_LEN and
+            len(request_key) == packets.KEY_LEN and
+            len(handshake_packet)):
+        assert isinstance(packets.build_request_packet(data),
+                          packets.RequestPacket)
+    else:
+        with pytest.raises(errors.MalformedPacketError):
+            packets.build_request_packet(data)

--- a/tests/test_packets.py
+++ b/tests/test_packets.py
@@ -9,6 +9,7 @@ from unmessage import packets
 from pyaxo import b2a
 
 
+CORRECT_LEN_INTRO_DATA = random(1)
 CORRECT_LEN_IV = random(packets.IV_LEN)
 CORRECT_LEN_HASH = random(packets.HASH_LEN)
 CORRECT_LEN_KEY = random(packets.KEY_LEN)
@@ -20,6 +21,32 @@ CORRECT_LEN_IDENTITY = random(1)
 
 def join_encode_data(lines):
     return packets.LINESEP.join([b2a(l) for l in lines])
+
+
+@given(
+    binary(),
+    binary(),
+    binary(),
+)
+@example(
+    CORRECT_LEN_IV,
+    CORRECT_LEN_HASH,
+    CORRECT_LEN_INTRO_DATA,
+)
+def test_build_intro_packet(iv,
+                            iv_hash,
+                            data):
+    data = join_encode_data([iv,
+                             iv_hash,
+                             data])
+    if (len(iv) == packets.IV_LEN and
+            len(iv_hash) == packets.HASH_LEN and
+            len(data)):
+        assert isinstance(packets.build_intro_packet(data),
+                          packets.IntroductionPacket)
+    else:
+        with pytest.raises(errors.MalformedPacketError):
+            packets.build_intro_packet(data)
 
 
 @given(


### PR DESCRIPTION
Most of the checks of the functions that build unMessage packets from a netstring do size checking and therefore can be easily tested with hypothesis.

Other tests for input that might or might not be base64 encoded could be added as well.

(This PR has been opened mostly to test the coverage diff, but can group all of these similar packet tests)