### PR TITLE
Create a separate class for serialization

### DIFF
--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -7,19 +7,6 @@ from unmessage.elements import ID_LENGTH, get_random_id
 from unmessage.packets import ElementPacket
 
 
-def test_serialize_element_payload(element, serialized_payload):
-    assert element.serialize() == serialized_payload
-
-
-def test_deserialize_element_payload(content, serialized_payload):
-    assert (Element.deserialize(serialized_payload) ==
-            Element(content))
-
-
-def test_serialize_deserialize_element_payload(element):
-    assert Element.deserialize(element.serialize()) == element
-
-
 ELEMENT_CLASSES = {cls.__name__: cls for cls in Element.__subclasses__()}
 
 

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from pyaxo import hash_, a2b, b2a
 
@@ -73,7 +75,7 @@ def test_get_random_element_id():
 
 @pytest.fixture
 def serialized_payload(content):
-    return '{{"content": "{}"}}'.format(content)
+    return json.dumps({'content': content})
 
 
 @pytest.fixture
@@ -87,12 +89,10 @@ def file_checksum():
 
 
 @pytest.fixture
-def file_request_serialized_payload(content, file_size, file_checksum):
-    return ('{{'
-            '"content": "{}", '
-            '"checksum": "{}", '
-            '"size": {}'
-            '}}'.format(content, file_checksum, file_size))
+def file_request_serialized_payload(content, file_checksum, file_size):
+    return json.dumps({'content': content,
+                       'checksum': file_checksum,
+                       'size': file_size})
 
 
 @pytest.fixture

--- a/tests/test_serializable.py
+++ b/tests/test_serializable.py
@@ -1,0 +1,73 @@
+import json
+
+import attr
+import pytest
+
+from unmessage.utils import Serializable
+
+
+ATTRIBUTE = 'attribute'
+FILTERED_OUT_ATTRIBUTE = 'filtered_out_attribute'
+VALUE = 'value'
+
+
+def test_serialize(simple_serializable, serialized):
+    assert simple_serializable.serialize() == serialized
+
+
+def test_deserialize(serialized):
+    assert (SimpleSerializable.deserialize(serialized) ==
+            SimpleSerializable(VALUE))
+
+
+def test_serialize_deserialize(simple_serializable):
+    assert (SimpleSerializable.deserialize(simple_serializable.serialize()) ==
+            simple_serializable)
+
+
+def test_serialize_filtered(filtered_serializable, serialized):
+    assert filtered_serializable.serialize() == serialized
+
+
+@attr.s
+class Attribute(object):
+    name = attr.ib()
+
+
+ATTRIBUTES = {ATTRIBUTE: Attribute(ATTRIBUTE),
+              FILTERED_OUT_ATTRIBUTE: Attribute(FILTERED_OUT_ATTRIBUTE)}
+
+
+@pytest.mark.parametrize('attribute',
+                         ATTRIBUTES.values(),
+                         ids=ATTRIBUTES.keys())
+def test_filter(attribute, filtered_serializable):
+    assert (filtered_serializable.filter_attrs(attribute) is
+            (attribute.name in filtered_serializable.filtered_attr_names))
+
+
+@attr.s
+class SimpleSerializable(Serializable):
+    attribute = attr.ib()
+
+
+@pytest.fixture
+def simple_serializable():
+    return SimpleSerializable(VALUE)
+
+
+@attr.s
+class FilteredSerializable(SimpleSerializable):
+    filtered_attr_names = [ATTRIBUTE]
+
+    filtered_out_attribute = attr.ib(default=None)
+
+
+@pytest.fixture
+def filtered_serializable():
+    return FilteredSerializable(VALUE, VALUE)
+
+
+@pytest.fixture
+def serialized():
+    return json.dumps({ATTRIBUTE: VALUE})

--- a/unmessage/elements.py
+++ b/unmessage/elements.py
@@ -1,4 +1,3 @@
-import json
 from functools import wraps
 
 import attr
@@ -7,6 +6,7 @@ from pyaxo import b2a
 
 from . import errors
 from .packets import ElementPacket
+from .utils import Serializable
 
 
 def raise_incomplete(f):
@@ -80,9 +80,10 @@ class PartialElement(dict):
 
 
 @attr.s
-class Element(object):
-    element_classes = None
+class Element(Serializable):
     filtered_attr_names = ['content']
+
+    element_classes = None
 
     type_ = 'elmt'
 
@@ -106,22 +107,8 @@ class Element(object):
                                    for c in cls.__subclasses__() + [cls]}
         return cls.element_classes
 
-    @classmethod
-    def filter_attrs(cls, attribute, value):
-        if cls.filtered_attr_names is None:
-            return True
-        else:
-            return attribute.name in cls.filtered_attr_names
-
-    @classmethod
-    def deserialize(cls, data):
-        return cls(**json.loads(data))
-
     def __str__(self):
         return self.content
-
-    def serialize(self):
-        return json.dumps(attr.asdict(self, filter=self.filter_attrs))
 
 
 @attr.s

--- a/unmessage/utils.py
+++ b/unmessage/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 from functools import wraps
@@ -7,6 +8,25 @@ from nacl.public import PublicKey
 from twisted.internet.threads import deferToThread as fork
 
 from . import errors
+
+
+@attr.s
+class Serializable(object):
+    filtered_attr_names = None
+
+    @classmethod
+    def filter_attrs(cls, attribute, value):
+        if cls.filtered_attr_names is None:
+            return True
+        else:
+            return attribute.name in cls.filtered_attr_names
+
+    @classmethod
+    def deserialize(cls, data):
+        return cls(**json.loads(data))
+
+    def serialize(self):
+        return json.dumps(attr.asdict(self, filter=self.filter_attrs))
 
 
 def default_factory_attrib(factory, init=False, takes_self=True):

--- a/unmessage/utils.py
+++ b/unmessage/utils.py
@@ -15,7 +15,7 @@ class Serializable(object):
     filtered_attr_names = None
 
     @classmethod
-    def filter_attrs(cls, attribute, value):
+    def filter_attrs(cls, attribute, value=None):
         if cls.filtered_attr_names is None:
             return True
         else:


### PR DESCRIPTION
These changes separate serialization from the `Element` class so that any class can be serialized by subclassing `Serializable`.